### PR TITLE
Get branch name from substitutions field

### DIFF
--- a/lib/sparrow/cloud_build/build.rb
+++ b/lib/sparrow/cloud_build/build.rb
@@ -24,15 +24,15 @@ module Sparrow
       end
 
       def branch
-        repo_source["branchName"]
+        substitutions["BRANCH_NAME"]
       end
 
       def repo_name
-        repo_source["repoName"]
+        resolved_repo_source["repoName"]
       end
 
       def commit_sha
-        data["sourceProvenance"]["resolvedRepoSource"]["commitSha"]
+        resolved_repo_source["commitSha"]
       end
 
       def log_url
@@ -53,12 +53,20 @@ module Sparrow
 
       private
 
-      def repo_source
-        source["repoSource"] || {}
+      def resolved_repo_source
+        source_provenance["resolvedRepoSource"] || {}
+      end
+
+      def source_provenance
+        data["sourceProvenance"] || {}
       end
 
       def source
         data["source"] || {}
+      end
+
+      def substitutions
+        data["substitutions"] || {}
       end
     end
   end

--- a/spec/fixtures/builds/branch/master.json
+++ b/spec/fixtures/builds/branch/master.json
@@ -1,31 +1,31 @@
 {
-  "id": "8aec3f61-76a9-4c5c-a255-41636df09bf0",
+  "id": "6d37bb72-861a-4033-a084-17f869370f7c",
   "projectId": "project-id",
   "status": "SUCCESS",
   "source": {
     "repoSource": {
       "projectId": "project-id",
       "repoName": "github_anipos_sparrow",
-      "branchName": "master"
+      "commitSha": "238947c2440028cfff5388c7fba3aa4ca7ae92f5"
     }
   },
   "steps": [
     {
-      "name": "gcr.io/kaniko-project/executor",
+      "name": "gcr.io/kaniko-project/executor:v0.22.0",
       "args": [
         "--dockerfile=Dockerfile",
-        "--destination=gcr.io/project-id/sparrow:b996c13441128cb91d9e41374e0ec071b5cef7b4",
+        "--destination=gcr.io/project-id/sparrow:238947c2440028cfff5388c7fba3aa4ca7ae92f5",
         "--destination=gcr.io/project-id/sparrow:latest",
         "--cache=true",
         "--cache-ttl=336h"
       ],
       "timing": {
-        "startTime": "2019-09-27T22:22:42.696858600Z",
-        "endTime": "2019-09-27T22:24:32.078255694Z"
+        "startTime": "2020-06-18T01:50:14.627939737Z",
+        "endTime": "2020-06-18T01:52:05.052053580Z"
       },
       "pullTiming": {
-        "startTime": "2019-09-27T22:22:42.696858600Z",
-        "endTime": "2019-09-27T22:22:44.120975302Z"
+        "startTime": "2020-06-18T01:50:14.627939737Z",
+        "endTime": "2020-06-18T01:50:19.313795043Z"
       },
       "status": "SUCCESS"
     }
@@ -33,37 +33,49 @@
   "results": {
     "buildStepImages": [
       ""
+    ],
+    "buildStepOutputs": [
+      ""
     ]
   },
-  "createTime": "2019-09-27T22:22:32.910458414Z",
-  "startTime": "2019-09-27T22:22:34.534482567Z",
-  "finishTime": "2019-09-27T22:24:33.295939Z",
-  "timeout": "1800s",
-  "logsBucket": "gs://918090106759.cloudbuild-logs.googleusercontent.com",
+  "createTime": "2020-06-18T01:50:07.064842944Z",
+  "startTime": "2020-06-18T01:50:08.047254579Z",
+  "finishTime": "2020-06-18T01:52:05.991312Z",
+  "timeout": "600s",
+  "queueTtl": "3600s",
+  "logsBucket": "gs://12345.cloudbuild-logs.googleusercontent.com",
   "sourceProvenance": {
     "resolvedRepoSource": {
       "projectId": "project-id",
       "repoName": "github_anipos_sparrow",
-      "commitSha": "b996c13441128cb91d9e41374e0ec071b5cef7b4"
+      "commitSha": "238947c2440028cfff5388c7fba3aa4ca7ae92f5"
     }
   },
-  "buildTriggerId": "e9ba2adc-297b-4c79-9305-3fc6c3768db5",
+  "buildTriggerId": "f420008f-0c36-424b-bef5-b3c42972cf99",
   "options": {
     "substitutionOption": "ALLOW_LOOSE",
+    "dynamicSubstitutions": true,
     "logging": "LEGACY"
   },
-  "logUrl": "https://console.cloud.google.com/gcr/builds/8aec3f61-76a9-4c5c-a255-41636df09bf0?project=918090106759",
+  "logUrl": "https://console.cloud.google.com/cloud-build/builds/6d37bb72-861a-4033-a084-17f869370f7c?project=12345",
+  "substitutions": {
+    "BRANCH_NAME": "master",
+    "COMMIT_SHA": "238947c2440028cfff5388c7fba3aa4ca7ae92f5",
+    "REPO_NAME": "github_anipos_sparrow",
+    "REVISION_ID": "238947c2440028cfff5388c7fba3aa4ca7ae92f5",
+    "SHORT_SHA": "238947c"
+  },
   "tags": [
-    "trigger-e9ba2adc-297b-4c79-9305-3fc6c3768db5"
+    "trigger-f420008f-0c36-424b-bef5-b3c42972cf99"
   ],
   "timing": {
     "BUILD": {
-      "startTime": "2019-09-27T22:22:42.696822159Z",
-      "endTime": "2019-09-27T22:24:32.136251297Z"
+      "startTime": "2020-06-18T01:50:13.732582142Z",
+      "endTime": "2020-06-18T01:52:05.052127186Z"
     },
     "FETCHSOURCE": {
-      "startTime": "2019-09-27T22:22:35.872631719Z",
-      "endTime": "2019-09-27T22:22:42.625503314Z"
+      "startTime": "2020-06-18T01:50:08.901969759Z",
+      "endTime": "2020-06-18T01:50:13.732513472Z"
     }
   }
 }

--- a/spec/sparrow/jobs/git_ops/rewrite_spec.rb
+++ b/spec/sparrow/jobs/git_ops/rewrite_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Sparrow::Jobs::GitOps::Rewrite do
   let(:build) do
     Sparrow::CloudBuild::Build.new(
-      JSON.parse(fixture("builds", "status", "success.json"))
+      JSON.parse(fixture("builds", "branch", "master.json"))
     )
   end
 


### PR DESCRIPTION
Problem

A cloud build's build message has the union field `revision` which can
be one of the following.

- `branchName`
- `tagName`
- `commitSha`

Originally we used `branchName` to get the branch name of a build but
cloud build suddenly prioritizes commitSha. As a result we get empty
branch name.

Solution

Use `substitutions.BRANCH_NAME` to get branch name.