### PR TITLE
Sanitize branch name

### DIFF
--- a/lib/sparrow/jobs/git_ops/rewrite.rb
+++ b/lib/sparrow/jobs/git_ops/rewrite.rb
@@ -137,7 +137,11 @@ module Sparrow
         end
 
         def branch_name
-          "heads/gitops-#{@build.commit_sha}-#{@name}"
+          "heads/gitops-#{@build.commit_sha}-#{sanitized_name}"
+        end
+
+        def sanitized_name
+          @name.tr("/", "-")
         end
 
         def title


### PR DESCRIPTION
Using multiple "/" in branch name leads to "unprocessable entity" error
when creating branch.