### PR TITLE
Revert "Update ruby Docker tag to v3.1.0 (#220)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM ruby:3.1.0 as base
+FROM ruby:3.0.3 as base
 
 ENV LANG C.UTF-8
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.1.0
+FROM ruby:3.0.3
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
Because ruby v3.1.0 is incompatible with google-protobuf.

> google-protobuf-3.19.1-x86_64-linux requires ruby version >= 2.3, < 3.1.dev,
> which is incompatible with the current version, ruby 3.1.0p0                                                                           


This reverts commit 05d3fd26065e7591a3ae5f4e8d939a35f6523571.
