### PR TITLE
Switch elgohr/Publish-Docker-Github-Action to v4

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish Docker Image to Docker Hub.
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v4
         with:
           name: anipos/sparrow
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
> elgohr/Publish-Docker-Github-Action@master has been deprecated.
> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.