### PR TITLE
Fix rewrite to support the Cloud Build GitHub App

### DIFF
--- a/lib/sparrow/jobs/git_ops/rewrite.rb
+++ b/lib/sparrow/jobs/git_ops/rewrite.rb
@@ -62,14 +62,18 @@ module Sparrow
         end
 
         def source_repo_match?
-          cloud_source_repo == @build.repo_name
+          [github_legacy_source_repo, github_app_source_repo].include?(@build.repo_name)
         end
 
-        # TODO(shouichi): Handle other git providers (e.g., bitbucket).
-        def cloud_source_repo
+        def github_legacy_source_repo
           # Cloud Source Repositories downcases org/repo names (e.g., Foo/Bar
           # -> foo_bar).
           "github_#{@source_repo.tr('/', '_')}".downcase
+        end
+
+        def github_app_source_repo
+          # only repo name is given from github app
+          @source_repo.split("/").last
         end
 
         def no_changes?

--- a/spec/sparrow/jobs/git_ops/rewrite_spec.rb
+++ b/spec/sparrow/jobs/git_ops/rewrite_spec.rb
@@ -1,36 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe Sparrow::Jobs::GitOps::Rewrite do
-  let(:build) do
-    Sparrow::CloudBuild::Build.new(
-      JSON.parse(fixture("builds", "branch", "master", "github_legacy.json"))
-    )
-  end
+  shared_examples "rewrite" do |json|
+    let(:build) do
+      Sparrow::CloudBuild::Build.new(
+        JSON.parse(fixture("builds", "branch", "master", json))
+      )
+    end
 
-  let(:rewrite) do
-    described_class.new(
-      build:,
-      name: "spec",
-      source_repo: "anipos/sparrow",
-      config_repo: "anipos/sparrow",
-      erb_path: "spec/fixtures/git_ops/template.erb",
-      out_path: "spec/fixtures/git_ops/rewritten"
-    )
-  end
+    let(:rewrite) do
+      described_class.new(
+        build:,
+        name: "spec",
+        source_repo: "anipos/sparrow",
+        config_repo: "anipos/sparrow",
+        erb_path: "spec/fixtures/git_ops/template.erb",
+        out_path: "spec/fixtures/git_ops/rewritten"
+      )
+    end
 
-  it "creates a pull request" do
-    VCR.use_cassette("create_pull_request") do
-      pr = rewrite.run
+    it "creates a pull request" do
+      VCR.use_cassette("create_pull_request") do
+        pr = rewrite.run
 
-      expect(pr.title).to eq("Update tag to #{build.commit_sha}")
+        expect(pr.title).to eq("Update tag to #{build.commit_sha}")
+      end
+    end
+
+    it "do nothing when the same pull request exists" do
+      VCR.use_cassette("pull_request_exists") do
+        pr = rewrite.run
+
+        expect(pr).to be_nil
+      end
     end
   end
 
-  it "do nothing when the same pull request exists" do
-    VCR.use_cassette("pull_request_exists") do
-      pr = rewrite.run
+  describe "rewrite github_legacy.json" do
+    include_examples "rewrite", "github_legacy.json"
+  end
 
-      expect(pr).to be_nil
-    end
+  describe "rewrite github_app.json" do
+    include_examples "rewrite", "github_app.json"
   end
 end


### PR DESCRIPTION
I added support for the Cloud Build GitHub App as a build trigger in the last PR (https://github.com/anipos/sparrow/pull/363).
However, the change of REPO_NAME was not supported, and it still does not work well.

https://github.com/anipos/sparrow/pull/363#issuecomment-1299979866

I fixed the rewrite part to support the new connection method and added missing tests.