### PR TITLE
Fix not to run docker build workflow on tag creation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,11 +48,10 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -61,7 +60,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,13 +1,18 @@
-name: docker build
+name: Docker Build
 
 on:
-  - push
-  - pull_request
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - '**'
 
 jobs:
-  build:
+  docker_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Build Docker Image.
-        run: docker build .
+      - uses: actions/checkout@v3
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -1,12 +1,14 @@
+name: Docker Push
+
 on:
   push:
     tags:
       - 'v*'
 jobs:
-  build:
+  docker_push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: docker/metadata-action@v4
         id: meta
         with:


### PR DESCRIPTION
Also use docker/build-push-action for docker build workflow for
consistency.
